### PR TITLE
Disable the migration module completely

### DIFF
--- a/lib/octopus.rb
+++ b/lib/octopus.rb
@@ -163,7 +163,7 @@ require 'octopus/shard_tracking/attribute'
 require 'octopus/shard_tracking/dynamic'
 
 require 'octopus/model'
-require 'octopus/migration' unless Octopus.config[:migrations] == false
+# require 'octopus/migration' unless Octopus.config[:migrations] == false
 require 'octopus/association'
 require 'octopus/collection_association'
 require 'octopus/has_and_belongs_to_many_association' unless Octopus.rails41?


### PR DESCRIPTION
This update will completely disable the migration module.
